### PR TITLE
add missing keys to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,13 @@
   },
   "scripts": {
     "test": "node test.js"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jed/dynamo-streams.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jed/dynamo-streams/issues"
+  },
+  "homepage": "https://github.com/jed/dynamo-streams#readme"
 }


### PR DESCRIPTION
Added some missing keys to package.json, created by running `npm init` in the existing project. This is most helpful for people who find the project via npmjs.com and want to see the repository. npmjs.com will automatically link over to GitHub with the `repository` set.
