### PR TITLE
use the 'finish' event for firing callback hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ var put = dbStreams.createPutStream({TableName: "stooges"})
 put.write({id: 4, name: "Curly"})
 put.end()
 
-put.on("end", function() {
+put.on("finish", function() {
   var read = dbStreams.createScanStream({TableName: "stooges"})
 
   read.on("data", console.log)
@@ -94,7 +94,7 @@ var put = dbStreams.createDeleteStream({TableName: "stooges"})
 put.write({id: 2})
 put.end()
 
-put.on("end", function() {
+put.on("finish", function() {
   var read = dbStreams.createScanStream({TableName: "stooges"})
 
   read.on("data", console.log)
@@ -117,7 +117,7 @@ sync.write({id: 4, name: "Curly"})
 
 sync.end()
 
-put.on("end", function() {
+put.on("finish", function() {
   var read = dbStreams.createScanStream({TableName: "stooges"})
 
   read.on("data", console.log)


### PR DESCRIPTION
The stream docs seem to indicate that `finish` is the better callback to use, since it is fired after the queue of pending reads/writes is empty.  I also had the direct experience that using `end` caused the callbacks to fire too early.